### PR TITLE
Immagen responsive de fondo

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2,7 +2,7 @@
 body{
     margin: 0;
     padding: 0;
-    background-image: url("fondo.gif");
+    background: url("fondo.gif") no-repeat center center fixed;
     background-size: cover;
     font-family: 'Quicksand', sans-serif;
 }


### PR DESCRIPTION
La imagen de fondo se adapta a los tamaños de pantalla, por lo que ya no aparecen varias veces al verse desde pantalla con formatos diferente a 16:9